### PR TITLE
`ArrayHelpers::random()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,3 +53,7 @@ All notable changes to `array-helpers` will be documented in this file
 ## 1.2.0 - 2021-03-31
 - bump min sfneal/actions version to 2.0
 - refactor `ChunkSizer` to extend `Action` instead of `ActionStatic`
+
+
+## 1.3.0 - 2021-07-29
+- add `random` method to `ArrayHelpers` with helper function for retrieving random array elements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,4 +56,5 @@ All notable changes to `array-helpers` will be documented in this file
 
 
 ## 1.3.0 - 2021-07-29
+- cut illuminate/support from composer dev requirements
 - add `random` method to `ArrayHelpers` with helper function for retrieving random array elements

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=5.7.0",
-        "scrutinizer/ocular": "^1.8",
-        "illuminate/support": "*"
+        "scrutinizer/ocular": "^1.8"
     },
     "autoload": {
         "psr-4": {

--- a/src/ArrayHelpers.php
+++ b/src/ArrayHelpers.php
@@ -183,4 +183,18 @@ class ArrayHelpers
     {
         return $this->arrayValuesEqual(null);
     }
+
+    /**
+     * Retrieve a random array of elements.
+     *
+     * @param int $items
+     * @return array
+     */
+    public function random(int $items): array
+    {
+        $keys = array_rand($this->array, $items);
+        return array_filter($this->array, function ($value, $key) use ($keys) {
+            return in_array($key, $keys);
+        }, ARRAY_FILTER_USE_BOTH);
+    }
 }

--- a/src/ArrayHelpers.php
+++ b/src/ArrayHelpers.php
@@ -4,6 +4,8 @@ namespace Sfneal\Helpers\Arrays;
 
 class ArrayHelpers
 {
+    // todo: remove 'array' prefix from method names
+
     /**
      * @var array
      */

--- a/src/ArrayHelpers.php
+++ b/src/ArrayHelpers.php
@@ -193,6 +193,7 @@ class ArrayHelpers
     public function random(int $items): array
     {
         $keys = array_rand($this->array, $items);
+
         return array_filter($this->array, function ($value, $key) use ($keys) {
             return in_array($key, $keys);
         }, ARRAY_FILTER_USE_BOTH);

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -145,6 +145,20 @@ function arrayValuesNull(array $array): bool
     return (new ArrayHelpers($array))->arrayValuesNull();
 }
 
+if (! function_exists('arrayRandom')) {
+    /**
+     * Retrieve a random array of elements.
+     *
+     * @param array $array
+     * @param int $items
+     * @return array
+     */
+    function arrayRandom(array $array, int $items): array
+    {
+        return (new ArrayHelpers($array))->random($items);
+    }
+}
+
 /**
  * Only declare function if Illuminate/Collection is installed.
  */

--- a/tests/ArrayHelpersTest.php
+++ b/tests/ArrayHelpersTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\TestCase;
 
 class ArrayHelpersTest extends TestCase
 {
+    // todo: refactor to use class
+
     /** @test */
     public function arrayChunks()
     {
@@ -239,5 +241,29 @@ class ArrayHelpersTest extends TestCase
 
         $isNull = arrayValuesNull($array2);
         $this->assertTrue($isNull);
+    }
+
+    /** @test */
+    public function random()
+    {
+        $items = 3;
+        $array = [
+            'sfneal/laravel-helpers',
+            'symfony/console',
+            'spatie/laravel-view-models',
+            'webmozart/assert',
+            'psr/http-message',
+            'sebastian/global-state',
+        ];
+
+        $randoms = arrayRandom($array, $items);
+
+        $this->assertNotNull($randoms);
+        $this->assertIsArray($randoms);
+        $this->assertCount($items, $randoms);
+
+        foreach ($randoms as $random) {
+            $this->assertTrue(in_array($random, $array));
+        }
     }
 }

--- a/tests/ArrayHelpersTest.php
+++ b/tests/ArrayHelpersTest.php
@@ -259,7 +259,6 @@ class ArrayHelpersTest extends TestCase
         $randoms = arrayRandom($array, $items);
 
         $this->assertNotNull($randoms);
-        $this->assertIsArray($randoms);
         $this->assertCount($items, $randoms);
 
         foreach ($randoms as $random) {


### PR DESCRIPTION
- cut illuminate/support from composer dev requirements
- add `random` method to `ArrayHelpers` with helper function for retrieving random array elements