### PR TITLE
`arrayUnset()` method refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,3 +71,8 @@ All notable changes to `array-helpers` will be documented in this file
 
 ## 1.4.1 - 2021-08-03
 - optimize `ChunkSizerTest` to use dataProviders
+
+
+## 1.5.0 - 2021-08-03
+- refactor `ArrayHelpers::arrayUnset()` method to `arrayPop()` because an element is being 'popped' from the array
+- make `ArrayHelpers::arrayUnset()` method for removing an element & returning a new array

--- a/src/ArrayHelpers.php
+++ b/src/ArrayHelpers.php
@@ -195,6 +195,21 @@ class ArrayHelpers
     }
 
     /**
+     * Remove a key from an array & the new array without the key.
+     *
+     * @param string $key
+     * @return array
+     */
+    public function arrayUnset(string $key): array
+    {
+        // Remove the value from the array
+        unset($this->array[$key]);
+
+        // Return the new array
+        return $this->array;
+    }
+
+    /**
      * Determine if all values in an array are null.
      *
      * @return bool

--- a/src/ArrayHelpers.php
+++ b/src/ArrayHelpers.php
@@ -178,12 +178,11 @@ class ArrayHelpers
 
     /**
      * Remove a key from an array & return the key's value.
-     * // todo: refactor to arrayPop.
      *
      * @param string $key
      * @return mixed
      */
-    public function arrayUnset(string $key)
+    public function arrayPop(string $key)
     {
         // Get the value
         $value = $this->array[$key];

--- a/src/ArrayHelpers.php
+++ b/src/ArrayHelpers.php
@@ -197,13 +197,15 @@ class ArrayHelpers
     /**
      * Remove a key from an array & the new array without the key.
      *
-     * @param string $key
+     * @param array|string $keys
      * @return array
      */
-    public function arrayUnset(string $key): array
+    public function arrayUnset($keys): array
     {
-        // Remove the value from the array
-        unset($this->array[$key]);
+        // Remove the values from the array
+        foreach ((array) $keys as $key) {
+            unset($this->array[$key]);
+        }
 
         // Return the new array
         return $this->array;

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -138,12 +138,12 @@ function arrayPop(array $array, string $key)
  * Remove a key from an array & the new array without the key.
  *
  * @param array $array
- * @param string $key
+ * @param array|string $keys
  * @return array
  */
-function arrayUnset(array $array, string $key): array
+function arrayUnset(array $array, $keys): array
 {
-    return (new ArrayHelpers($array))->arrayUnset($key);
+    return (new ArrayHelpers($array))->arrayUnset($keys);
 }
 
 /**

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -129,9 +129,9 @@ function chunkSizer(int $array_size, int $min = 0, int $max = null, int $divisor
  * @param string $key
  * @return mixed
  */
-function arrayUnset(array $array, string $key)
+function arrayPop(array $array, string $key)
 {
-    return (new ArrayHelpers($array))->arrayUnset($key);
+    return (new ArrayHelpers($array))->arrayPop($key);
 }
 
 /**

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -135,6 +135,18 @@ function arrayPop(array $array, string $key)
 }
 
 /**
+ * Remove a key from an array & the new array without the key.
+ *
+ * @param array $array
+ * @param string $key
+ * @return array
+ */
+function arrayUnset(array $array, string $key): array
+{
+    return (new ArrayHelpers($array))->arrayUnset($key);
+}
+
+/**
  * Determine if all values in an array are null.
  *
  * @param array $array

--- a/tests/Feature/PopTest.php
+++ b/tests/Feature/PopTest.php
@@ -5,9 +5,9 @@ namespace Sfneal\Helpers\Arrays\Tests\Feature;
 use Sfneal\Helpers\Arrays\ArrayHelpers;
 use Sfneal\Helpers\Arrays\Tests\TestCase;
 
-class UnsetTest extends TestCase
+class PopTest extends TestCase
 {
-    public function arrayUnsetProvider(): array
+    public function arrayPopProvider(): array
     {
         return [
             [
@@ -39,34 +39,34 @@ class UnsetTest extends TestCase
     }
 
     /**
-     * @dataProvider arrayUnsetProvider
+     * @dataProvider arrayPopProvider
      * @param array $array
      * @param $key
      * @param $expected
      */
-    public function test_array_unset(array $array, $key, $expected)
+    public function test_pop_unset(array $array, $key, $expected)
     {
-        $this->assertArrayUnset(
-            (new ArrayHelpers($array))->arrayUnset($key),
+        $this->assertPopUnset(
+            (new ArrayHelpers($array))->arrayPop($key),
             $expected
         );
     }
 
     /**
-     * @dataProvider arrayUnsetProvider
+     * @dataProvider arrayPopProvider
      * @param array $array
      * @param $key
      * @param $expected
      */
-    public function test_array_unset_helper(array $array, $key, $expected)
+    public function test_array_pop_helper(array $array, $key, $expected)
     {
-        $this->assertArrayUnset(
-            arrayUnset($array, $key),
+        $this->assertPopUnset(
+            arrayPop($array, $key),
             $expected
         );
     }
 
-    public function assertArrayUnset($actual, $expected)
+    public function assertPopUnset($actual, $expected)
     {
         $this->assertNotNull($actual);
         $this->assertEquals($expected, $actual);

--- a/tests/Feature/UnsetTest.php
+++ b/tests/Feature/UnsetTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Sfneal\Helpers\Arrays\Tests\Feature;
+
+use Sfneal\Helpers\Arrays\ArrayHelpers;
+use Sfneal\Helpers\Arrays\Tests\TestCase;
+
+class UnsetTest extends TestCase
+{
+    public function arrayUnsetProvider(): array
+    {
+        return [
+            [
+                ['red' => 22, 'green' => 44, 'blue' => 23, 'purple' => 23],
+                'green',
+                ['red' => 22, 'blue' => 23, 'purple' => 23],
+            ],
+            [
+                ['red' => 22, 'green' => 44, 'blue' => 23, 'purple' => 23],
+                'blue',
+                ['red' => 22, 'green' => 44, 'purple' => 23],
+            ],
+            [
+                ['red' => 36, 'black' => 88, 'white' => 72, 'blue' => 4],
+                'black',
+                ['red' => 36, 'white' => 72, 'blue' => 4],
+            ],
+            [
+                ['red' => 'Detroit', 'green' => 'Dallas', 'blue' => 'Vancouver', 'purple' => 'Los Angeles'],
+                'red',
+                ['green' => 'Dallas', 'blue' => 'Vancouver', 'purple' => 'Los Angeles'],
+            ],
+            [
+                ['red' => 'Detroit', 'green' => 'Dallas', 'blue' => 'Vancouver', 'purple' => 'Los Angeles'],
+                'blue',
+                ['red' => 'Detroit', 'green' => 'Dallas', 'purple' => 'Los Angeles'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider arrayUnsetProvider
+     * @param array $array
+     * @param $key
+     * @param $expected
+     */
+    public function test_array_unset(array $array, $key, $expected)
+    {
+        $this->assertArrayUnset(
+            (new ArrayHelpers($array))->arrayUnset($key),
+            $expected,
+            $key
+        );
+    }
+
+    /**
+     * @dataProvider arrayUnsetProvider
+     * @param array $array
+     * @param $key
+     * @param $expected
+     */
+    public function test_array_unset_helper(array $array, $key, $expected)
+    {
+        $this->assertArrayUnset(
+            arrayUnset($array, $key),
+            $expected,
+            $key
+        );
+    }
+
+    public function assertArrayUnset($actual, $expected, $key)
+    {
+        $this->assertNotNull($actual);
+        $this->assertIsArray($actual);
+        $this->assertArrayNotHasKey($key, $actual);
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/Feature/UnsetTest.php
+++ b/tests/Feature/UnsetTest.php
@@ -35,6 +35,32 @@ class UnsetTest extends TestCase
                 'blue',
                 ['red' => 'Detroit', 'green' => 'Dallas', 'purple' => 'Los Angeles'],
             ],
+
+            [
+                ['red' => 22, 'green' => 44, 'blue' => 23, 'purple' => 23],
+                ['green', 'purple'],
+                ['red' => 22, 'blue' => 23],
+            ],
+            [
+                ['red' => 22, 'green' => 44, 'blue' => 23, 'purple' => 23],
+                ['blue', 'red'],
+                ['green' => 44, 'purple' => 23],
+            ],
+            [
+                ['red' => 36, 'black' => 88, 'white' => 72, 'blue' => 4],
+                ['black', 'white'],
+                ['red' => 36, 'blue' => 4],
+            ],
+            [
+                ['red' => 'Detroit', 'green' => 'Dallas', 'blue' => 'Vancouver', 'purple' => 'Los Angeles'],
+                ['red', 'purple'],
+                ['green' => 'Dallas', 'blue' => 'Vancouver'],
+            ],
+            [
+                ['red' => 'Detroit', 'green' => 'Dallas', 'blue' => 'Vancouver', 'purple' => 'Los Angeles'],
+                ['blue', 'green'],
+                ['red' => 'Detroit', 'purple' => 'Los Angeles'],
+            ],
         ];
     }
 
@@ -68,11 +94,13 @@ class UnsetTest extends TestCase
         );
     }
 
-    public function assertArrayUnset($actual, $expected, $key)
+    public function assertArrayUnset($actual, $expected, $keys)
     {
         $this->assertNotNull($actual);
         $this->assertIsArray($actual);
-        $this->assertArrayNotHasKey($key, $actual);
+        foreach ((array) $keys as $key) {
+            $this->assertArrayNotHasKey($key, $actual);
+        }
         $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/Unit/ArrayHelpersTest.php
+++ b/tests/Unit/ArrayHelpersTest.php
@@ -7,8 +7,6 @@ use Sfneal\Helpers\Arrays\Tests\TestCase;
 
 class ArrayHelpersTest extends TestCase
 {
-    // todo: refactor to use class
-
     /** @test */
     public function array_diff_flat()
     {


### PR DESCRIPTION
- refactor `ArrayHelpers::arrayUnset()` method to `arrayPop()` because an element is being 'popped' from the array
- make `ArrayHelpers::arrayUnset()` method for removing an element & returning a new array

fixes #24 