### PR TITLE
v2.0 - remove 'array' prefix from `ArrayHelpers` method names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,3 +86,7 @@ All notable changes to `array-helpers` will be documented in this file
 - add `ArrayHelpers::diffFlat()` method with the same functionality as the `array_diff_flat()` helper
 - make `DiffFlatTest` for testing `ArrayHelpers::diffFlat()` & `array_diff_flat()` helper function
 - add `ArrayHelpers::arrayValuesNotEqual()` method & `arrayValuesNotEqual()` helper
+
+
+## 2.0.0 - 2021-08-03
+- refactor `ArrayHelpers` to not use the 'array' prefix in method names

--- a/src/ArrayHelpers.php
+++ b/src/ArrayHelpers.php
@@ -30,7 +30,7 @@ class ArrayHelpers
      * @param bool $preserve_keys
      * @return array
      */
-    public function arrayChunks(int $min = 0, int $max = null, bool $no_remainders = false, bool $preserve_keys = true): array
+    public function chunks(int $min = 0, int $max = null, bool $no_remainders = false, bool $preserve_keys = true): array
     {
         $chunks = array_chunk(
             $this->array,
@@ -56,7 +56,7 @@ class ArrayHelpers
      * @param bool $nest_keys
      * @return array
      */
-    public function arrayFlattenKeys(bool $nest_keys = true): array
+    public function flattenKeys(bool $nest_keys = true): array
     {
         // todo: possible use while loop for multi level nesting?
         $flat = [];
@@ -84,7 +84,7 @@ class ArrayHelpers
      * @param array|string $keys
      * @return array
      */
-    public function arrayRemoveKeys($keys): array
+    public function removeKeys($keys): array
     {
         $all_keys = array_keys($this->array);
         foreach ((array) $keys as $key) {
@@ -102,7 +102,7 @@ class ArrayHelpers
      * @param array $array2
      * @return array
      */
-    public function sumArrays(array $array2): array
+    public function sum(array $array2): array
     {
         // todo: add ability to pass array of arrays
         $array = [];
@@ -118,7 +118,7 @@ class ArrayHelpers
      *
      * @return bool
      */
-    public function arrayValuesUnique(): bool
+    public function valuesUnique(): bool
     {
         try {
             // Count the number of unique array values
@@ -145,7 +145,7 @@ class ArrayHelpers
      * @param mixed $value
      * @return bool
      */
-    public function arrayValuesEqual($value): bool
+    public function valuesEqual($value): bool
     {
         // Check if all array values are equal to a certain value
         return count(array_keys($this->array, $value)) == count($this->array);
@@ -157,9 +157,9 @@ class ArrayHelpers
      * @param mixed $value
      * @return bool
      */
-    public function arrayValuesNotEqual($value): bool
+    public function valuesNotEqual($value): bool
     {
-        return ! $this->arrayValuesEqual($value);
+        return ! $this->valuesEqual($value);
     }
 
     /**
@@ -167,7 +167,7 @@ class ArrayHelpers
      *
      * @return bool
      */
-    public function arrayHasKeys(): bool
+    public function hasKeys(): bool
     {
         // Array doesn't have keys if the array is the same as the array values
         if ($this->array == array_values($this->array)) {
@@ -183,7 +183,7 @@ class ArrayHelpers
      * @param array $except
      * @return array
      */
-    public function array_except(array $except): array
+    public function except(array $except): array
     {
         return array_diff_key($this->array, array_flip((array) $except));
     }
@@ -194,7 +194,7 @@ class ArrayHelpers
      * @param string $key
      * @return mixed
      */
-    public function arrayPop(string $key)
+    public function pop(string $key)
     {
         // Get the value
         $value = $this->array[$key];
@@ -212,7 +212,7 @@ class ArrayHelpers
      * @param array|string $keys
      * @return array
      */
-    public function arrayUnset($keys): array
+    public function unset($keys): array
     {
         // Remove the values from the array
         foreach ((array) $keys as $key) {
@@ -228,9 +228,9 @@ class ArrayHelpers
      *
      * @return bool
      */
-    public function arrayValuesNull(): bool
+    public function valuesNull(): bool
     {
-        return $this->arrayValuesEqual(null);
+        return $this->valuesEqual(null);
     }
 
     /**

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -19,7 +19,7 @@ function arrayChunks(array $array,
                      bool $no_remainders = false,
                      bool $preserve_keys = true): array
 {
-    return (new ArrayHelpers($array))->arrayChunks($min, $max, $no_remainders, $preserve_keys);
+    return (new ArrayHelpers($array))->chunks($min, $max, $no_remainders, $preserve_keys);
 }
 
 /**
@@ -31,7 +31,7 @@ function arrayChunks(array $array,
  */
 function arrayFlattenKeys(array $array, bool $nest_keys = true): array
 {
-    return (new ArrayHelpers($array))->arrayFlattenKeys($nest_keys);
+    return (new ArrayHelpers($array))->flattenKeys($nest_keys);
 }
 
 /**
@@ -43,7 +43,7 @@ function arrayFlattenKeys(array $array, bool $nest_keys = true): array
  */
 function arrayRemoveKeys(array $array, $keys): array
 {
-    return (new ArrayHelpers($array))->arrayRemoveKeys($keys);
+    return (new ArrayHelpers($array))->removeKeys($keys);
 }
 
 /**
@@ -55,7 +55,7 @@ function arrayRemoveKeys(array $array, $keys): array
  */
 function sumArrays(array $array1, array $array2): array
 {
-    return (new ArrayHelpers($array1))->sumArrays($array2);
+    return (new ArrayHelpers($array1))->sum($array2);
 }
 
 /**
@@ -66,7 +66,7 @@ function sumArrays(array $array1, array $array2): array
  */
 function arrayValuesUnique(array $array): bool
 {
-    return (new ArrayHelpers($array))->arrayValuesUnique();
+    return (new ArrayHelpers($array))->valuesUnique();
 }
 
 /**
@@ -78,7 +78,7 @@ function arrayValuesUnique(array $array): bool
  */
 function arrayValuesEqual(array $array, $value): bool
 {
-    return (new ArrayHelpers($array))->arrayValuesEqual($value);
+    return (new ArrayHelpers($array))->valuesEqual($value);
 }
 
 /**
@@ -90,7 +90,7 @@ function arrayValuesEqual(array $array, $value): bool
  */
 function arrayValuesNotEqual(array $array, $value): bool
 {
-    return (new ArrayHelpers($array))->arrayValuesNotEqual($value);
+    return (new ArrayHelpers($array))->valuesNotEqual($value);
 }
 
 /**
@@ -101,7 +101,7 @@ function arrayValuesNotEqual(array $array, $value): bool
  */
 function arrayHasKeys(array $array): bool
 {
-    return (new ArrayHelpers($array))->arrayHasKeys();
+    return (new ArrayHelpers($array))->hasKeys();
 }
 
 if (! function_exists('array_except')) {
@@ -114,7 +114,7 @@ if (! function_exists('array_except')) {
      */
     function array_except(array $original, array $except): array
     {
-        return (new ArrayHelpers($original))->array_except($except);
+        return (new ArrayHelpers($original))->except($except);
     }
 }
 
@@ -147,7 +147,7 @@ function chunkSizer(int $array_size, int $min = 0, int $max = null, int $divisor
  */
 function arrayPop(array $array, string $key)
 {
-    return (new ArrayHelpers($array))->arrayPop($key);
+    return (new ArrayHelpers($array))->pop($key);
 }
 
 /**
@@ -159,7 +159,7 @@ function arrayPop(array $array, string $key)
  */
 function arrayUnset(array $array, $keys): array
 {
-    return (new ArrayHelpers($array))->arrayUnset($keys);
+    return (new ArrayHelpers($array))->unset($keys);
 }
 
 /**
@@ -170,7 +170,7 @@ function arrayUnset(array $array, $keys): array
  */
 function arrayValuesNull(array $array): bool
 {
-    return (new ArrayHelpers($array))->arrayValuesNull();
+    return (new ArrayHelpers($array))->valuesNull();
 }
 
 if (! function_exists('arrayRandom')) {

--- a/tests/Feature/ChunksTest.php
+++ b/tests/Feature/ChunksTest.php
@@ -57,7 +57,7 @@ class ChunksTest extends TestCase
         $this->assertArrayChunks(
             $args,
             $expected,
-            (new ArrayHelpers($args['array']))->arrayChunks($args['min'], $args['max'], $args['no_remainders'])
+            (new ArrayHelpers($args['array']))->chunks($args['min'], $args['max'], $args['no_remainders'])
         );
     }
 

--- a/tests/Feature/ChunksTest.php
+++ b/tests/Feature/ChunksTest.php
@@ -52,7 +52,7 @@ class ChunksTest extends TestCase
      * @param array $args
      * @param array $expected
      */
-    public function test_array_chunks(array $args, array $expected)
+    public function test_chunks(array $args, array $expected)
     {
         $this->assertArrayChunks(
             $args,
@@ -66,7 +66,7 @@ class ChunksTest extends TestCase
      * @param array $args
      * @param array $expected
      */
-    public function test_array_chunks_helper(array $args, array $expected)
+    public function test_chunks_helper(array $args, array $expected)
     {
         $this->assertArrayChunks(
             $args,

--- a/tests/Feature/DiffFlatTest.php
+++ b/tests/Feature/DiffFlatTest.php
@@ -67,7 +67,7 @@ class DiffFlatTest extends TestCase
      * @param array $args
      * @param array $expected
      */
-    public function test_diff_flat_array_helper(array $args, array $expected)
+    public function test_diff_flat_helper(array $args, array $expected)
     {
         // Set $toArray param
         $args[2] = true;

--- a/tests/Feature/ExceptTest.php
+++ b/tests/Feature/ExceptTest.php
@@ -37,7 +37,7 @@ class ExceptTest extends TestCase
     public function test_except(array $array, array $except, array $expected)
     {
         $this->assertArrayExcept(
-            (new ArrayHelpers($array))->array_except($except),
+            (new ArrayHelpers($array))->except($except),
             $expected
         );
     }

--- a/tests/Feature/ExceptTest.php
+++ b/tests/Feature/ExceptTest.php
@@ -34,7 +34,7 @@ class ExceptTest extends TestCase
      * @param array $except
      * @param array $expected
      */
-    public function test_array_except(array $array, array $except, array $expected)
+    public function test_except(array $array, array $except, array $expected)
     {
         $this->assertArrayExcept(
             (new ArrayHelpers($array))->array_except($except),
@@ -48,7 +48,7 @@ class ExceptTest extends TestCase
      * @param array $except
      * @param array $expected
      */
-    public function test_array_except_helper(array $array, array $except, array $expected)
+    public function test_except_helper(array $array, array $except, array $expected)
     {
         $this->assertArrayExcept(
             array_except($array, $except),

--- a/tests/Feature/FlattenKeysTest.php
+++ b/tests/Feature/FlattenKeysTest.php
@@ -144,7 +144,7 @@ class FlattenKeysTest extends TestCase
         $this->assertFlattenKeys(
             $args,
             $expected,
-            (new ArrayHelpers($args['array']))->arrayFlattenKeys($args['nest_keys'])
+            (new ArrayHelpers($args['array']))->flattenKeys($args['nest_keys'])
         );
     }
 

--- a/tests/Feature/HasKeysTest.php
+++ b/tests/Feature/HasKeysTest.php
@@ -78,7 +78,7 @@ class HasKeysTest extends TestCase
     {
         $this->assertHasKeys(
             $array,
-            (new ArrayHelpers($array))->arrayHasKeys()
+            (new ArrayHelpers($array))->hasKeys()
         );
     }
 
@@ -89,7 +89,7 @@ class HasKeysTest extends TestCase
     {
         $this->assertDoesntHaveKeys(
             $array,
-            (new ArrayHelpers($array))->arrayHasKeys()
+            (new ArrayHelpers($array))->hasKeys()
         );
     }
 

--- a/tests/Feature/HasKeysTest.php
+++ b/tests/Feature/HasKeysTest.php
@@ -74,7 +74,7 @@ class HasKeysTest extends TestCase
     /**
      * @dataProvider arrayHasKeysProvider
      */
-    public function test_array_array_has_keys(array $array)
+    public function test_array_has_keys(array $array)
     {
         $this->assertHasKeys(
             $array,
@@ -85,7 +85,7 @@ class HasKeysTest extends TestCase
     /**
      * @dataProvider arrayDoesntHaveKeysProvider
      */
-    public function test_array_doesnt_have_keys(array $array)
+    public function test_doesnt_have_keys(array $array)
     {
         $this->assertDoesntHaveKeys(
             $array,
@@ -96,7 +96,7 @@ class HasKeysTest extends TestCase
     /**
      * @dataProvider arrayHasKeysProvider
      */
-    public function test_array_array_has_keys_helper(array $array)
+    public function test_array_has_keys_helper(array $array)
     {
         $this->assertHasKeys(
             $array,
@@ -107,7 +107,7 @@ class HasKeysTest extends TestCase
     /**
      * @dataProvider arrayDoesntHaveKeysProvider
      */
-    public function test_array_doesnt_have_keys_helper(array $array)
+    public function test_doesnt_have_keys_helper(array $array)
     {
         $this->assertDoesntHaveKeys(
             $array,

--- a/tests/Feature/PopTest.php
+++ b/tests/Feature/PopTest.php
@@ -58,7 +58,7 @@ class PopTest extends TestCase
      * @param $key
      * @param $expected
      */
-    public function test_array_pop_helper(array $array, $key, $expected)
+    public function test_pop_helper(array $array, $key, $expected)
     {
         $this->assertPopUnset(
             arrayPop($array, $key),

--- a/tests/Feature/PopTest.php
+++ b/tests/Feature/PopTest.php
@@ -47,7 +47,7 @@ class PopTest extends TestCase
     public function test_pop_unset(array $array, $key, $expected)
     {
         $this->assertPopUnset(
-            (new ArrayHelpers($array))->arrayPop($key),
+            (new ArrayHelpers($array))->pop($key),
             $expected
         );
     }

--- a/tests/Feature/RemoveKeysTest.php
+++ b/tests/Feature/RemoveKeysTest.php
@@ -54,7 +54,7 @@ class RemoveKeysTest extends TestCase
         $this->assertRemoveKeys(
             $args,
             $expected,
-            (new ArrayHelpers($args['array']))->arrayRemoveKeys($args['keysToRemove'])
+            (new ArrayHelpers($args['array']))->removeKeys($args['keysToRemove'])
         );
     }
 

--- a/tests/Feature/SumTest.php
+++ b/tests/Feature/SumTest.php
@@ -37,7 +37,7 @@ class SumTest extends TestCase
     public function test_sum_arrays(array $array, array $expected)
     {
         $this->assertSumArrays(
-            (new ArrayHelpers($array[0]))->sumArrays($array[1]),
+            (new ArrayHelpers($array[0]))->sum($array[1]),
             $expected
         );
     }

--- a/tests/Feature/UnsetTest.php
+++ b/tests/Feature/UnsetTest.php
@@ -73,7 +73,7 @@ class UnsetTest extends TestCase
     public function test_unset(array $array, $key, $expected)
     {
         $this->assertArrayUnset(
-            (new ArrayHelpers($array))->arrayUnset($key),
+            (new ArrayHelpers($array))->unset($key),
             $expected,
             $key
         );

--- a/tests/Feature/UnsetTest.php
+++ b/tests/Feature/UnsetTest.php
@@ -70,7 +70,7 @@ class UnsetTest extends TestCase
      * @param $key
      * @param $expected
      */
-    public function test_array_unset(array $array, $key, $expected)
+    public function test_unset(array $array, $key, $expected)
     {
         $this->assertArrayUnset(
             (new ArrayHelpers($array))->arrayUnset($key),
@@ -85,7 +85,7 @@ class UnsetTest extends TestCase
      * @param $key
      * @param $expected
      */
-    public function test_array_unset_helper(array $array, $key, $expected)
+    public function test_unset_helper(array $array, $key, $expected)
     {
         $this->assertArrayUnset(
             arrayUnset($array, $key),

--- a/tests/Feature/ValuesEqualTest.php
+++ b/tests/Feature/ValuesEqualTest.php
@@ -54,7 +54,7 @@ class ValuesEqualTest extends TestCase
     /**
      * @dataProvider arrayValuesEqualProvider
      */
-    public function test_array_values_are_equal(array $array, $value)
+    public function test_values_are_equal(array $array, $value)
     {
         $this->assertValuesAreEqual(
             $array,
@@ -65,7 +65,7 @@ class ValuesEqualTest extends TestCase
     /**
      * @dataProvider arrayValuesNotEqualProvider
      */
-    public function test_array_values_not_equal(array $array, $value)
+    public function test_values_not_equal(array $array, $value)
     {
         $this->assertValuesAreEqual(
             $array,
@@ -76,7 +76,7 @@ class ValuesEqualTest extends TestCase
     /**
      * @dataProvider arrayValuesEqualProvider
      */
-    public function test_array_values_are_equal_helper(array $array, $value)
+    public function test_values_are_equal_helper(array $array, $value)
     {
         $this->assertValuesAreEqual(
             $array,
@@ -87,7 +87,7 @@ class ValuesEqualTest extends TestCase
     /**
      * @dataProvider arrayValuesNotEqualProvider
      */
-    public function test_array_values_not_equal_helper(array $array, $value)
+    public function test_values_not_equal_helper(array $array, $value)
     {
         $this->assertValuesAreEqual(
             $array,

--- a/tests/Feature/ValuesEqualTest.php
+++ b/tests/Feature/ValuesEqualTest.php
@@ -58,7 +58,7 @@ class ValuesEqualTest extends TestCase
     {
         $this->assertValuesAreEqual(
             $array,
-            (new ArrayHelpers($array))->arrayValuesEqual($value)
+            (new ArrayHelpers($array))->valuesEqual($value)
         );
     }
 
@@ -69,7 +69,7 @@ class ValuesEqualTest extends TestCase
     {
         $this->assertValuesAreEqual(
             $array,
-            (new ArrayHelpers($array))->arrayValuesNotEqual($value)
+            (new ArrayHelpers($array))->valuesNotEqual($value)
         );
     }
 

--- a/tests/Feature/ValuesNullTest.php
+++ b/tests/Feature/ValuesNullTest.php
@@ -54,7 +54,7 @@ class ValuesNullTest extends TestCase
     {
         $this->assertValuesAreNull(
             $array,
-            (new ArrayHelpers($array))->arrayValuesNull()
+            (new ArrayHelpers($array))->valuesNull()
         );
     }
 
@@ -65,7 +65,7 @@ class ValuesNullTest extends TestCase
     {
         $this->assertValuesNotNull(
             $array,
-            (new ArrayHelpers($array))->arrayValuesNull()
+            (new ArrayHelpers($array))->valuesNull()
         );
     }
 

--- a/tests/Feature/ValuesNullTest.php
+++ b/tests/Feature/ValuesNullTest.php
@@ -7,7 +7,7 @@ use Sfneal\Helpers\Arrays\Tests\TestCase;
 
 class ValuesNullTest extends TestCase
 {
-    public function arrayValuesNullProvider(): array
+    public function valuesNullProvider(): array
     {
         return [
             [
@@ -27,7 +27,7 @@ class ValuesNullTest extends TestCase
         ];
     }
 
-    public function arrayValuesNotNullProvider(): array
+    public function valuesNotNullProvider(): array
     {
         return [
             [
@@ -48,9 +48,9 @@ class ValuesNullTest extends TestCase
     }
 
     /**
-     * @dataProvider arrayValuesNullProvider
+     * @dataProvider valuesNullProvider
      */
-    public function test_array_values_are_null(array $array)
+    public function test_values_are_null(array $array)
     {
         $this->assertValuesAreNull(
             $array,
@@ -59,9 +59,9 @@ class ValuesNullTest extends TestCase
     }
 
     /**
-     * @dataProvider arrayValuesNotNullProvider
+     * @dataProvider valuesNotNullProvider
      */
-    public function test_array_values_not_null(array $array)
+    public function test_values_not_null(array $array)
     {
         $this->assertValuesNotNull(
             $array,
@@ -70,9 +70,9 @@ class ValuesNullTest extends TestCase
     }
 
     /**
-     * @dataProvider arrayValuesNullProvider
+     * @dataProvider valuesNullProvider
      */
-    public function test_array_values_are_null_helper(array $array)
+    public function test_values_are_null_helper(array $array)
     {
         $this->assertValuesAreNull(
             $array,
@@ -81,9 +81,9 @@ class ValuesNullTest extends TestCase
     }
 
     /**
-     * @dataProvider arrayValuesNotNullProvider
+     * @dataProvider valuesNotNullProvider
      */
-    public function test_array_values_not_null_helper(array $array)
+    public function test_values_not_null_helper(array $array)
     {
         $this->assertValuesNotNull(
             $array,

--- a/tests/Feature/ValuesUniqueTest.php
+++ b/tests/Feature/ValuesUniqueTest.php
@@ -7,7 +7,7 @@ use Sfneal\Helpers\Arrays\Tests\TestCase;
 
 class ValuesUniqueTest extends TestCase
 {
-    public function arrayValuesUniqueProvider(): array
+    public function valuesUniqueProvider(): array
     {
         return [
             [
@@ -41,7 +41,7 @@ class ValuesUniqueTest extends TestCase
         ];
     }
 
-    public function arrayValuesNotUniqueProvider(): array
+    public function valuesNotUniqueProvider(): array
     {
         return [
             [
@@ -74,9 +74,9 @@ class ValuesUniqueTest extends TestCase
     }
 
     /**
-     * @dataProvider arrayValuesUniqueProvider
+     * @dataProvider valuesUniqueProvider
      */
-    public function test_array_values_are_unique(array $array)
+    public function test_values_are_unique(array $array)
     {
         $this->assertValuesAreUnique(
             $array,
@@ -85,9 +85,9 @@ class ValuesUniqueTest extends TestCase
     }
 
     /**
-     * @dataProvider arrayValuesNotUniqueProvider
+     * @dataProvider valuesNotUniqueProvider
      */
-    public function test_array_values_not_unique(array $array)
+    public function test_values_not_unique(array $array)
     {
         $this->assertValuesNotUnique(
             $array,
@@ -96,9 +96,9 @@ class ValuesUniqueTest extends TestCase
     }
 
     /**
-     * @dataProvider arrayValuesUniqueProvider
+     * @dataProvider valuesUniqueProvider
      */
-    public function test_array_values_are_unique_helper(array $array)
+    public function test_values_are_unique_helper(array $array)
     {
         $this->assertValuesAreUnique(
             $array,
@@ -107,9 +107,9 @@ class ValuesUniqueTest extends TestCase
     }
 
     /**
-     * @dataProvider arrayValuesNotUniqueProvider
+     * @dataProvider valuesNotUniqueProvider
      */
-    public function test_array_values_not_unique_helper(array $array)
+    public function test_values_not_unique_helper(array $array)
     {
         $this->assertValuesNotUnique(
             $array,

--- a/tests/Feature/ValuesUniqueTest.php
+++ b/tests/Feature/ValuesUniqueTest.php
@@ -80,7 +80,7 @@ class ValuesUniqueTest extends TestCase
     {
         $this->assertValuesAreUnique(
             $array,
-            (new ArrayHelpers($array))->arrayValuesUnique()
+            (new ArrayHelpers($array))->valuesUnique()
         );
     }
 
@@ -91,7 +91,7 @@ class ValuesUniqueTest extends TestCase
     {
         $this->assertValuesNotUnique(
             $array,
-            (new ArrayHelpers($array))->arrayValuesUnique()
+            (new ArrayHelpers($array))->valuesUnique()
         );
     }
 


### PR DESCRIPTION
- refactor `ArrayHelpers` to not use the 'array' prefix in method names

fixes #9 