### PR TITLE
Fix issues with `ArrayUtility::except()` method altering the original array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,3 +103,9 @@ All notable changes to `array-helpers` will be documented in this file
 
 ## 3.1.1 - 2021-08-05
 - add test methods to `FlattenKeysTest` that tests data sets using $nest_keys param set as true & false
+
+
+## 3.2.0 - 2021-08-05
+- fix issues with `ArrayUtility::except()` method altering the original array
+- add test method to `ArrayHelpersUnitTest` that uses method stacking to test multiple methods
+- add $separator param to `ArrayUtility::flattenKeys()` method

--- a/src/Utils/ArrayUtility.php
+++ b/src/Utils/ArrayUtility.php
@@ -130,7 +130,7 @@ class ArrayUtility
     }
 
     /**
-     * Remove specific arrays of keys without modifying the original array.
+     * Remove specific arrays of keys.
      *
      * @param array $except
      * @return self

--- a/src/Utils/ArrayUtility.php
+++ b/src/Utils/ArrayUtility.php
@@ -130,14 +130,14 @@ class ArrayUtility
     }
 
     /**
-     * Remove specific arrays of keys.
+     * Remove specific arrays of keys without altering the original $array.
      *
      * @param array $except
      * @return self
      */
     public function except(array $except): self
     {
-        return $this->set(array_diff_key($this->array, array_flip((array) $except)));
+        return new self(array_diff_key($this->array, array_flip((array) $except)));
     }
 
     /**

--- a/src/Utils/ArrayUtility.php
+++ b/src/Utils/ArrayUtility.php
@@ -141,6 +141,19 @@ class ArrayUtility
     }
 
     /**
+     * Retrieve an array with only the keys provided in the $only param.
+     *
+     * @param array $only
+     * @return self
+     */
+    public function only(array $only): self
+    {
+        return $this->set(array_filter($this->array, function($key) use ($only) {
+            return in_array($key, $only);
+        }, ARRAY_FILTER_USE_KEY));
+    }
+
+    /**
      * Remove a key from an array & return the key's value.
      *
      * @param string $key

--- a/src/Utils/ArrayUtility.php
+++ b/src/Utils/ArrayUtility.php
@@ -87,9 +87,10 @@ class ArrayUtility
      * Flatten a multidimensional array into a 2D array without nested keys.
      *
      * @param bool $nest_keys
+     * @param string $separator
      * @return self
      */
-    public function flattenKeys(bool $nest_keys = true): self
+    public function flattenKeys(bool $nest_keys = true, string $separator = '_'): self
     {
         // todo: possible use while loop for multi level nesting?
         $flat = [];
@@ -98,7 +99,7 @@ class ArrayUtility
                 // If the key is an array, add each children keys to flattened array
                 foreach ($this->array[$key] as $k => $v) {
                     if ($nest_keys) {
-                        $flat[$key.'_'.$k] = $v;
+                        $flat[$key.$separator.$k] = $v;
                     } else {
                         $flat[$k] = $v;
                     }

--- a/src/Utils/ArrayUtility.php
+++ b/src/Utils/ArrayUtility.php
@@ -149,7 +149,7 @@ class ArrayUtility
      */
     public function only(array $only): self
     {
-        return $this->set(array_filter($this->array, function($key) use ($only) {
+        return $this->set(array_filter($this->array, function ($key) use ($only) {
             return in_array($key, $only);
         }, ARRAY_FILTER_USE_KEY));
     }

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -104,8 +104,9 @@ function arrayHasKeys(array $array): bool
 }
 
 if (! function_exists('array_except')) {
+    // todo: refactor to `arrayExcept()`
     /**
-     * Remove specific arrays of keys without modifying the original array.
+     * Remove specific arrays of keys.
      *
      * @param array $original
      * @param array $except
@@ -114,6 +115,20 @@ if (! function_exists('array_except')) {
     function array_except(array $original, array $except): array
     {
         return ArrayHelpers::from($original)->except($except)->get();
+    }
+}
+
+if (! function_exists('arrayOnly')) {
+    /**
+     * Retrieve an array with only the keys provided in the $only param.
+     *
+     * @param array $original
+     * @param array $only
+     * @return array
+     */
+    function arrayOnly(array $original, array $only): array
+    {
+        return ArrayHelpers::from($original)->only($only)->get();
     }
 }
 

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -27,11 +27,12 @@ function arrayChunks(array $array,
  *
  * @param array $array
  * @param bool $nest_keys
+ * @param string $separator
  * @return array
  */
-function arrayFlattenKeys(array $array, bool $nest_keys = true): array
+function arrayFlattenKeys(array $array, bool $nest_keys = true, string $separator = '_'): array
 {
-    return ArrayHelpers::from($array)->flattenKeys($nest_keys)->get();
+    return ArrayHelpers::from($array)->flattenKeys($nest_keys, $separator)->get();
 }
 
 /**

--- a/tests/Feature/OnlyTest.php
+++ b/tests/Feature/OnlyTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Sfneal\Helpers\Arrays\Tests\Feature;
+
+use Sfneal\Helpers\Arrays\ArrayHelpers;
+use Sfneal\Helpers\Arrays\Tests\TestCase;
+
+class OnlyTest extends TestCase
+{
+    public function onlyProvider(): array
+    {
+        return [
+            [
+                ['red' => 22, 'green' => 44, 'blue' => 23, 'purple' => 23],
+                ['red', 'green'],
+                ['red' => 22, 'green' => 44],
+            ],
+            [
+                ['red' => 22, 'green' => 44, 'blue' => 23, 'purple' => 23],
+                ['blue'],
+                ['blue' => 23],
+            ],
+            [
+                ['red' => 36, 'black' => 88, 'white' => 72, 'blue' => 4],
+                ['black', 'white'],
+                ['black' => 88, 'white' => 72],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider onlyProvider
+     * @param array $array
+     * @param array $only
+     * @param array $expected
+     */
+    public function test_only(array $array, array $only, array $expected)
+    {
+        $this->assertArrayOnly(
+            ArrayHelpers::from($array)->only($only)->get(),
+            $expected
+        );
+    }
+
+    /**
+     * @dataProvider onlyProvider
+     * @param array $array
+     * @param array $only
+     * @param array $expected
+     */
+    public function test_only_helper(array $array, array $only, array $expected)
+    {
+        $this->assertArrayOnly(
+            arrayOnly($array, $only),
+            $expected
+        );
+    }
+
+    public function assertArrayOnly($actual, $expected)
+    {
+        $this->assertIsArray($actual);
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/Feature/RandomTest.php
+++ b/tests/Feature/RandomTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sfneal\Helpers\Arrays\Tests\Feature;
+
+use Sfneal\Helpers\Arrays\ArrayHelpers;
+use Sfneal\Helpers\Arrays\Tests\TestCase;
+
+class RandomTest extends TestCase
+{
+    /** @test */
+    public function random()
+    {
+        $items = 3;
+        $array = [
+            'sfneal/laravel-helpers',
+            'symfony/console',
+            'spatie/laravel-view-models',
+            'webmozart/assert',
+            'psr/http-message',
+            'sebastian/global-state',
+        ];
+
+        $randoms = ArrayHelpers::from($array)->random($items)->get();
+
+        $this->assertNotNull($randoms);
+        $this->assertCount($items, $randoms);
+
+        foreach ($randoms as $random) {
+            $this->assertTrue(in_array($random, $array));
+        }
+    }
+}

--- a/tests/Unit/ArrayHelpersTest.php
+++ b/tests/Unit/ArrayHelpersTest.php
@@ -2,9 +2,86 @@
 
 namespace Sfneal\Helpers\Arrays\Tests\Unit;
 
+use Sfneal\Helpers\Arrays\ArrayHelpers;
 use Sfneal\Helpers\Arrays\Tests\TestCase;
 
 class ArrayHelpersTest extends TestCase
 {
+    /** @test */
+    public function set_starting_lineup()
+    {
+        $available = [
+            'marchand' => 63,
+            'bergeron' => 37,
+            'pastrnak' => 88,
+            'hall' => 71,
+            'coyle' => 13,
+            'haula' => 56,
+            'grzelcyk' => 46,
+            'mcavoy' => 73,
+            'forbert' => 24,
+            'carlo' => 25,
+        ];
 
+        // Remove non-starters from array
+        $starters = ArrayHelpers::from($available)->only([
+            'marchand',
+            'bergeron',
+            'pastrnak',
+            'grzelcyk',
+            'mcavoy',
+        ]);
+
+        $this->assertIsArray($starters->get());
+        $this->assertCount(5, $starters->get());
+        $this->assertTrue($starters->hasKeys());
+        $this->assertTrue($starters->valuesUnique());
+        $this->assertEquals(
+            [
+                'marchand' => 63,
+                'bergeron' => 37,
+                'pastrnak' => 88,
+                'grzelcyk' => 46,
+                'mcavoy' => 73,
+            ],
+            $starters->get()
+        );
+
+        // Extract only starting forwards by removing starting defencemen
+        $defencemen = [
+            'grzelcyk',
+            'mcavoy',
+        ];
+        $forwards = $starters->except($defencemen);
+
+        $this->assertIsArray($forwards->get());
+        $this->assertCount(3, $forwards->get());
+        $this->assertTrue($forwards->valuesUnique());
+        $this->assertEquals(
+            [
+                'marchand' => 63,
+                'bergeron' => 37,
+                'pastrnak' => 88,
+            ],
+            $forwards->get()
+        );
+
+        // Extract only starting defencemen
+        $defense = $starters->only($defencemen);
+
+        $this->assertIsArray($defense->get());
+        $this->assertCount(2, $defense->get());
+        $this->assertTrue($defense->valuesUnique());
+        $this->assertEquals(
+            [
+                'grzelcyk' => 46,
+                'mcavoy' => 73,
+            ],
+            $defense->get()
+        );
+
+        // Get players numbers (values)
+        $this->assertEquals(88, $forwards->pop('pastrnak'));
+        $this->assertEquals(73, $defense->pop('mcavoy'));
+    }
 }

--- a/tests/Unit/ArrayHelpersTest.php
+++ b/tests/Unit/ArrayHelpersTest.php
@@ -2,31 +2,9 @@
 
 namespace Sfneal\Helpers\Arrays\Tests\Unit;
 
-use Sfneal\Helpers\Arrays\ArrayHelpers;
 use Sfneal\Helpers\Arrays\Tests\TestCase;
 
 class ArrayHelpersTest extends TestCase
 {
-    /** @test */
-    public function random()
-    {
-        $items = 3;
-        $array = [
-            'sfneal/laravel-helpers',
-            'symfony/console',
-            'spatie/laravel-view-models',
-            'webmozart/assert',
-            'psr/http-message',
-            'sebastian/global-state',
-        ];
 
-        $randoms = ArrayHelpers::from($array)->random($items)->get();
-
-        $this->assertNotNull($randoms);
-        $this->assertCount($items, $randoms);
-
-        foreach ($randoms as $random) {
-            $this->assertTrue(in_array($random, $array));
-        }
-    }
 }


### PR DESCRIPTION
- fix issues with `ArrayUtility::except()` method altering the original array
- add test method to `ArrayHelpersUnitTest` that uses method stacking to test multiple methods
- add $separator param to `ArrayUtility::flattenKeys()` method