### PR TITLE
Add 'merge' methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,3 +109,8 @@ All notable changes to `array-helpers` will be documented in this file
 - fix issues with `ArrayUtility::except()` method altering the original array
 - add test method to `ArrayHelpersUnitTest` that uses method stacking to test multiple methods
 - add $separator param to `ArrayUtility::flattenKeys()` method
+
+
+## 3.3.0 - 2021-08-05
+- add `merge()` method to `ArrayUtility` for merging existing arrays
+- add `fromMerge()` method to `ArrayHelpers` for creating merged arrays

--- a/src/ArrayHelpers.php
+++ b/src/ArrayHelpers.php
@@ -18,6 +18,17 @@ class ArrayHelpers
     }
 
     /**
+     * Instantiate a `ArrayUtility` instance by passing multiple $arrays to the constructor to be merged.
+     *
+     * @param mixed ...$arrays
+     * @return ArrayUtility
+     */
+    public static function fromMerge(...$arrays): ArrayUtility
+    {
+        return new ArrayUtility(array_merge(...$arrays));
+    }
+
+    /**
      * Sum the values of two arrays.
      *
      * @param array $arrays

--- a/src/Utils/ArrayUtility.php
+++ b/src/Utils/ArrayUtility.php
@@ -155,6 +155,17 @@ class ArrayUtility
     }
 
     /**
+     * Merge arrays into the existing array.
+     *
+     * @param ...$arrays
+     * @return $this
+     */
+    public function merge(...$arrays): self
+    {
+        return $this->set(array_merge($this->array, ...$arrays));
+    }
+
+    /**
      * Remove a key from an array & return the key's value.
      *
      * @param string $key

--- a/tests/Feature/MergeTest.php
+++ b/tests/Feature/MergeTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Sfneal\Helpers\Arrays\Tests\Feature;
+
+use Sfneal\Helpers\Arrays\ArrayHelpers;
+use Sfneal\Helpers\Arrays\Tests\TestCase;
+
+class MergeTest extends TestCase
+{
+    // todo: add data providers with more levels of nesting
+    public function mergeProvider(): array
+    {
+        return [
+            [
+                [
+                    ['green' => 22, 'blue' => 54],
+                    ['red' => 36, 'purple' => 78],
+                    ['black' => 88, 'white' => 72],
+                ],
+                [
+                    'green' => 22,
+                    'blue' => 54,
+                    'red' => 36,
+                    'purple' => 78,
+                    'black' => 88,
+                    'white' => 72,
+                ],
+            ],
+
+            [
+                [
+                    [
+                        'marchand' => 63,
+                        'bergeron' => 37,
+                        'pastrnak' => 88,
+                    ],
+                    [
+                        'hall' => 71,
+                        'coyle' => 13,
+                        'haula' => 56,
+                    ],
+                    [
+                        'grzelcyk' => 46,
+                        'mcavoy' => 73,
+                    ],
+                    [
+                        'forbert' => 24,
+                        'carlo' => 25,
+                    ],
+                ],
+                [
+                    'marchand' => 63,
+                    'bergeron' => 37,
+                    'pastrnak' => 88,
+                    'hall' => 71,
+                    'coyle' => 13,
+                    'haula' => 56,
+                    'grzelcyk' => 46,
+                    'mcavoy' => 73,
+                    'forbert' => 24,
+                    'carlo' => 25,
+                ],
+            ],
+
+            [
+                [
+                    ['green' => 22, 'blue' => 54, 'red' => 36],
+                    ['purple' => 78, 'black' => 88, 'white' => 72],
+                ],
+                [
+                    'green' => 22,
+                    'blue' => 54,
+                    'red' => 36,
+                    'purple' => 78,
+                    'black' => 88,
+                    'white' => 72,
+                ],
+            ],
+
+            [
+                [
+                    ['green' => 22, 'blue' => 54],
+                    ['red' => 36],
+                    ['purple' => 78],
+                    ['black' => 88, 'white' => 72],
+                ],
+                [
+                    'green' => 22,
+                    'blue' => 54,
+                    'red' => 36,
+                    'purple' => 78,
+                    'black' => 88,
+                    'white' => 72,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider mergeProvider
+     * @param array $args
+     * @param array $expected
+     */
+    public function test_merge(array $args, array $expected)
+    {
+        $this->assertMerge(
+            $args,
+            $expected,
+            ArrayHelpers::fromMerge(...$args)->get()
+        );
+    }
+
+    public function assertMerge(array $args, array $expected, $flat)
+    {
+        $this->assertIsArray($flat);
+        $this->assertEquals($expected, $flat);
+
+        foreach ($args as $array) {
+            foreach (array_values($array) as $value) {
+                $this->assertTrue(in_array($value, array_values($flat)));
+            }
+
+            foreach (array_keys($array) as $key) {
+                $this->assertTrue(in_array($key, array_keys($flat)));
+            }
+        }
+    }
+}

--- a/tests/Feature/MergeTest.php
+++ b/tests/Feature/MergeTest.php
@@ -101,12 +101,28 @@ class MergeTest extends TestCase
      * @param array $args
      * @param array $expected
      */
-    public function test_merge(array $args, array $expected)
+    public function test_from_merge(array $args, array $expected)
     {
         $this->assertMerge(
             $args,
             $expected,
             ArrayHelpers::fromMerge(...$args)->get()
+        );
+    }
+
+    /**
+     * @dataProvider mergeProvider
+     * @param array $args
+     * @param array $expected
+     */
+    public function test_merge(array $args, array $expected)
+    {
+        $first = array_shift($args);
+
+        $this->assertMerge(
+            $args,
+            $expected,
+            ArrayHelpers::from($first)->merge(...$args)->get()
         );
     }
 


### PR DESCRIPTION
- add `merge()` method to `ArrayUtility` for merging existing arrays
- add `fromMerge()` method to `ArrayHelpers` for creating merged arrays

fixes #34 